### PR TITLE
Fix ambiguous type

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -9,11 +9,20 @@ is encoded as CBOR, which is small and easy to deserialise.
 
 The GHC plugin `GhcDump.Plugin` provides a Core-to-Core plugin which dumps a
 representation of the Core AST to file after every Core-to-Core pass. To use it,
-first install the `ghc-dump-core` package,
+first install the `ghc-dump-core` package, which provides the plugin to capture
+Core dumps:
 ```
 $ cabal install ghc-dump-core
 ```
-And then invoke GHC with the `-fplugin GhcDump.Plugin` flag,
+
+Next, install the `ghc-dump-util` package, which provides utilities for analyzing
+the results:
+```
+$ cabal install ghc-dump-util
+```
+
+
+Then invoke GHC with the `-fplugin GhcDump.Plugin` flag,
 ```
 $ ghc -fplugin GhcDump.Plugin -O Test.hs
 [1 of 1] Compiling Main             ( Test.hs, Test.o )

--- a/ghc-dump-util/Main.hs
+++ b/ghc-dump-util/Main.hs
@@ -64,7 +64,7 @@ modes = subparser
     filterCond :: Parser (Module -> Module)
     filterCond =
         fmap (maybe id filterBindings)
-        $ option (str >>= fmap Just . makeRegexM)
+        $ option ( (str :: ReadM String)  >>= fmap Just . makeRegexM)
                  (short 'f' <> long "filter" <> value Nothing <> help "filter bindings by name")
 
     prettyOpts :: Parser PrettyOpts

--- a/ghc-dump-util/ghc-dump-util.cabal
+++ b/ghc-dump-util/ghc-dump-util.cabal
@@ -33,5 +33,6 @@ executable ghc-dump
                        ansi-wl-pprint >= 0.6,
                        regex-tdfa >= 1.2,
                        regex-tdfa-text,
-                       optparse-applicative >= 0.13
+                       optparse-applicative >= 0.13,
+                       text >= 1.0
   default-language:    Haskell2010


### PR DESCRIPTION
`Main.hs` didn't compile under GHC 7.10.3 because it had an ambiguous type.
It looks like that type is fixed to `String` in 8.0.2 (presumably by a dependency
that's shifted). Let's fix it to `String` everywhere.