### PR TITLE
Create dump directory if missing

### DIFF
--- a/ghc-dump-core/GhcDump/Plugin.hs
+++ b/ghc-dump-core/GhcDump/Plugin.hs
@@ -10,6 +10,7 @@ import CoreMonad (pprPassDetails)
 import ErrUtils (showPass)
 import Text.Printf
 import System.FilePath
+import System.Directory
 
 import GhcDump.Convert
 
@@ -36,5 +37,6 @@ dumpIn dflags n phase guts = do
         fname = printf "%spass-%04u.cbor" prefix n
     showPass dflags $ "GhcDump: Dumping core to "++fname
     let in_dump_dir = maybe id (</>) (dumpDir dflags)
+    createDirectoryIfMissing True $ takeDirectory $ in_dump_dir fname
     BSL.writeFile (in_dump_dir fname) $ Ser.serialise (cvtModule phase guts)
     return guts

--- a/ghc-dump-core/ghc-dump-core.cabal
+++ b/ghc-dump-core/ghc-dump-core.cabal
@@ -39,7 +39,8 @@ library
                        text >=1.2 && <1.3,
                        filepath >= 1.4,
                        serialise >= 0.2 && <0.3,
-                       ghc >= 7.10 && < 8.8
+                       ghc >= 7.10 && < 8.8,
+                       directory < 1.4
   default-language:    Haskell2010
   if impl(ghc >= 8.0)
     ghc-options: -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances


### PR DESCRIPTION
Without this patch `BSL.writeFile` tries to write a file in a non-existing directory and fails if the module in question is hierarchical.