### PR TITLE
Add missing Setup.hs

### DIFF
--- a/ghc-dump-core/Setup.hs
+++ b/ghc-dump-core/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain


### PR DESCRIPTION
Otherwise cabal new-sdist'ed archive doesn't build.