### PR TITLE
Compress dumps with zstd

### DIFF
--- a/ghc-dump-core/GhcDump/Ast.hs
+++ b/ghc-dump-core/GhcDump/Ast.hs
@@ -9,7 +9,9 @@ import GHC.Generics
 import Data.Monoid hiding ((<>))
 import Data.Semigroup as Sem
 import qualified Data.ByteString as BS
-import Codec.Serialise
+import qualified Data.ByteString.Lazy as BSL
+import qualified Codec.Compression.Zstd.Lazy as Zstd
+import Codec.Serialise as Ser
 import qualified Data.Text as T
 
 #if MIN_VERSION_ghc(9,0,0)
@@ -257,6 +259,14 @@ instance Sem.Semigroup CoreStats where
 instance Monoid CoreStats where
     mempty = CoreStats 0 0 0 0 0
     mappend = (<>)
+
+writeSModule :: FilePath -> SModule -> IO ()
+writeSModule fname = do
+    BSL.writeFile fname . Zstd.compress 2 . Ser.serialise
+
+readSModule :: FilePath -> IO SModule
+readSModule fname = do
+    Ser.deserialise . Zstd.decompress <$> BSL.readFile fname
 
 {-
 data Rule' bndr var

--- a/ghc-dump-core/GhcDump/Plugin.hs
+++ b/ghc-dump-core/GhcDump/Plugin.hs
@@ -26,9 +26,8 @@ import Text.Printf
 
 import System.FilePath
 import System.Directory
-import qualified Data.ByteString.Lazy as BSL
-import qualified Codec.Serialise as Ser
 
+import GhcDump.Ast (writeSModule)
 import GhcDump.Convert
 
 plugin :: Plugin
@@ -69,9 +68,9 @@ showPass' s = do
 dumpIn :: DynFlags -> Int -> String -> ModGuts -> CoreM ModGuts
 dumpIn dflags n phase guts = do
     let prefix = fromMaybe "dump" $ dumpPrefix dflags
-        fname = printf "%spass-%04u.cbor" prefix n
+        fname = printf "%spass-%04u.cbor.zstd" prefix n
     showPass' $ "GhcDump: Dumping core to "++fname
     let in_dump_dir = maybe id (</>) (dumpDir dflags)
     liftIO $ createDirectoryIfMissing True $ takeDirectory $ in_dump_dir fname
-    liftIO $ BSL.writeFile (in_dump_dir fname) $ Ser.serialise (cvtModule dflags phase guts)
+    liftIO $ writeSModule (in_dump_dir fname) (cvtModule dflags phase guts)
     return guts

--- a/ghc-dump-core/ghc-dump-core.cabal
+++ b/ghc-dump-core/ghc-dump-core.cabal
@@ -52,7 +52,8 @@ library
                        filepath >= 1.4,
                        serialise >= 0.2 && <0.3,
                        ghc >= 7.10 && < 9.3,
-                       directory < 1.4
+                       directory < 1.4,
+                       zstd >= 0.1 && < 0.2
   default-language:    Haskell2010
   if impl(ghc >= 8.0)
     ghc-options: -Wcompat

--- a/ghc-dump-util/src/GhcDump/Util.hs
+++ b/ghc-dump-util/src/GhcDump/Util.hs
@@ -1,6 +1,6 @@
 module GhcDump.Util
     ( -- * Convenient IO
-      readDump, readDump'
+      readDump
       -- * Manipulating 'Type's
     , splitFunTys
     , splitForAlls
@@ -18,11 +18,8 @@ import qualified Codec.Serialise as Ser
 import GhcDump.Ast
 import GhcDump.Reconstruct
 
-readDump' :: FilePath -> IO SModule
-readDump' fname = Ser.deserialise <$> BSL.readFile fname
-
 readDump :: FilePath -> IO Module
-readDump fname = reconModule <$> readDump' fname
+readDump fname = reconModule <$> readSModule fname
 
 splitFunTys :: Type' bndr var -> [Type' bndr var]
 splitFunTys = go []


### PR DESCRIPTION
Despite being quite concise, CBOR dumps are still fairly compressible.
Take advantage of this using Zstd.

Closes #9.