### PR TITLE
capture phaseId in the module

### DIFF
--- a/ghc-dump-core/GhcDump/Ast.hs
+++ b/ghc-dump-core/GhcDump/Ast.hs
@@ -166,6 +166,7 @@ type SModule = Module' SBinder BinderId
 data Module' bndr var
     = Module { moduleName        :: ModuleName
              , modulePhase       :: T.Text
+             , modulePhaseId     :: Int
              , moduleTopBindings :: [TopBinding' bndr var]
              }
     deriving (Generic, Show)

--- a/ghc-dump-core/GhcDump/Convert.hs
+++ b/ghc-dump-core/GhcDump/Convert.hs
@@ -309,14 +309,14 @@ cvtLit l =
       Literal.LitInteger x _ -> Ast.LitInteger x
 #endif
 
-cvtModule :: DynFlags -> String -> ModGuts -> Ast.SModule
-cvtModule dflags phase guts =
+cvtModule :: DynFlags -> Int -> String -> ModGuts -> Ast.SModule
+cvtModule dflags phaseId phase guts =
     let ?env = Env {dflags}
-    in cvtModule' phase guts
+    in cvtModule' phaseId phase guts
 
-cvtModule' :: HasEnv => String -> ModGuts -> Ast.SModule
-cvtModule' phase guts =
-    Ast.Module name (T.pack phase) (map cvtTopBind $ mg_binds guts)
+cvtModule' :: HasEnv => Int -> String -> ModGuts -> Ast.SModule
+cvtModule' phaseId phase guts =
+    Ast.Module name (T.pack phase) phaseId (map cvtTopBind $ mg_binds guts)
   where
     name = cvtModuleName $ Module.moduleName $ mg_module guts
 

--- a/ghc-dump-core/GhcDump/Plugin.hs
+++ b/ghc-dump-core/GhcDump/Plugin.hs
@@ -72,5 +72,5 @@ dumpIn dflags n phase guts = do
     showPass' $ "GhcDump: Dumping core to "++fname
     let in_dump_dir = maybe id (</>) (dumpDir dflags)
     liftIO $ createDirectoryIfMissing True $ takeDirectory $ in_dump_dir fname
-    liftIO $ writeSModule (in_dump_dir fname) (cvtModule dflags phase guts)
+    liftIO $ writeSModule (in_dump_dir fname) (cvtModule dflags n phase guts)
     return guts

--- a/ghc-dump-util/src/GhcDump/Reconstruct.hs
+++ b/ghc-dump-util/src/GhcDump/Reconstruct.hs
@@ -33,7 +33,7 @@ getBinder (BinderMap m) bid
 -- "recon" == "reconstruct"
 
 reconModule :: SModule -> Module
-reconModule m = Module (moduleName m) (modulePhase m) binds
+reconModule m = Module (moduleName m) (modulePhase m) (modulePhaseId m) binds
   where
     binds = map reconTopBinding $ moduleTopBindings m
     bm = insertBinders (map (\(a,_,_) -> a) $ concatMap topBindings binds) emptyBinderMap


### PR DESCRIPTION
This is a very small change to capture some information that was already available. It's convenient for my project but I don't see why it shouldn't be there in general.