### PR TITLE
Save the SrcSpan of bindings

### DIFF
--- a/ghc-dump-core/GhcDump/Ast.hs
+++ b/ghc-dump-core/GhcDump/Ast.hs
@@ -147,6 +147,9 @@ instance Serialise TyCon
 data TyLit = NumTyLit Int
            | StrTyLit T.Text
            | CharTyLit Char
+           -- TyLit did not always exist, we weaken the definition 
+           -- with this constructor for backwards compatibility.
+           | UnknownLit
             deriving (Eq, Ord, Generic, Show)
 instance Serialise TyLit
 

--- a/ghc-dump-core/GhcDump/Ast.hs
+++ b/ghc-dump-core/GhcDump/Ast.hs
@@ -67,6 +67,7 @@ data Binder' bndr var = Binder { binderName   :: !T.Text
                                , binderIdInfo :: IdInfo bndr var
                                , binderIdDetails :: IdDetails
                                , binderType   :: Type' bndr var
+                               , binderSrcSpan :: SrcSpan
                                }
                       | TyBinder { binderName :: !T.Text
                                  , binderId   :: !BinderId
@@ -227,6 +228,7 @@ data SrcSpan = SrcSpan { spanFile  :: !T.Text
                        , spanStart :: !LineCol
                        , spanEnd   :: !LineCol
                        }
+            | NoSpan
                   deriving (Eq, Ord, Generic, Show)
 instance Serialise SrcSpan
 

--- a/ghc-dump-core/GhcDump/Ast.hs
+++ b/ghc-dump-core/GhcDump/Ast.hs
@@ -144,6 +144,12 @@ data TyCon = TyCon !T.Text !Unique
            deriving (Eq, Ord, Generic, Show)
 instance Serialise TyCon
 
+data TyLit = NumTyLit Int
+           | StrTyLit T.Text
+           | CharTyLit Char
+            deriving (Eq, Ord, Generic, Show)
+instance Serialise TyLit
+
 type SType = Type' SBinder BinderId
 type Type = Type' Binder Binder
 
@@ -153,7 +159,7 @@ data Type' bndr var
     | TyConApp TyCon [Type' bndr var]
     | AppTy (Type' bndr var) (Type' bndr var)
     | ForAllTy bndr (Type' bndr var)
-    | LitTy
+    | LitTy TyLit
     | CoercionTy
     deriving (Eq, Ord, Generic, Show)
 instance (Serialise bndr, Serialise var) => Serialise (Type' bndr var)
@@ -276,13 +282,3 @@ readSModule :: FilePath -> IO SModule
 readSModule fname = do
     Ser.deserialise . Zstd.decompress <$> BSL.readFile fname
 
-{-
-data Rule' bndr var
-    = Rule { ruleName :: T.Text
-           , ruleActivation :: Activation
-           , ruleFn :: Name
-           , ruleBinders :: [bndr]
-           , ruleRHS :: Expr' bndr var
-           , ruleAuto :: Bool
-           }
--}

--- a/ghc-dump-core/GhcDump/Convert.hs
+++ b/ghc-dump-core/GhcDump/Convert.hs
@@ -8,7 +8,6 @@ module GhcDump.Convert (cvtModule) where
 import Data.Bifunctor
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
-import GHC.Data.FastString (unpackFS)
 
 #if MIN_VERSION_ghc(9,0,0)
 import GHC.Types.Literal (Literal(..))
@@ -342,10 +341,17 @@ cvtModule' phaseId phase guts =
 cvtModuleName :: HasEnv => Module.ModuleName -> Ast.ModuleName
 cvtModuleName = Ast.ModuleName . fastStringToText . moduleNameFS
 
+#if MIN_VERSION_ghc(9,0,0)
 cvtTyLit :: HasEnv => Type.TyLit -> Ast.TyLit
 cvtTyLit (Type.NumTyLit n) = (Ast.NumTyLit (fromIntegral n))
-cvtTyLit (Type.StrTyLit s) = (Ast.StrTyLit (T.pack (unpackFS s)))
+cvtTyLit (Type.StrTyLit s) = (Ast.StrTyLit (T.pack (FastString.unpackFS s)))
+#if MIN_VERSION_ghc(9,2,0)
 cvtTyLit (Type.CharTyLit c) = (Ast.CharTyLit c)
+#endif
+#else
+cvtTyLit :: HasEnv => a -> Ast.TyLit
+cvtTyLit _ = Ast.UnknownLit
+#endif
 
 cvtType :: HasEnv => Type.Type -> Ast.SType
 #if MIN_VERSION_ghc(9,0,0)

--- a/ghc-dump-util/src/GhcDump/Pretty.hs
+++ b/ghc-dump-util/src/GhcDump/Pretty.hs
@@ -142,7 +142,7 @@ pprType' opts p (AppTy a b)       = maybeParens (p >= TyConPrec) $ pprType' opts
 pprType' opts p t@(ForAllTy _ _)  = let (bs, t') = splitForAlls t
                                     in maybeParens (p >= TyOpPrec)
                                        $ "forall" <+> hsep (map (pprBinder opts) bs) <> "." <+> pprType opts t'
-pprType' opts _ LitTy             = "LIT"
+pprType' opts _ (LitTy _)         = "LIT"
 pprType' opts _ CoercionTy        = "Co"
 
 maybeParens :: Bool -> Doc ann -> Doc ann

--- a/ghc-dump-util/src/GhcDump/Reconstruct.hs
+++ b/ghc-dump-util/src/GhcDump/Reconstruct.hs
@@ -107,5 +107,5 @@ reconType bm (AppTy x y) = AppTy (reconType bm x) (reconType bm y)
 reconType bm (ForAllTy b x) = let b' = reconBinder bm b
                                   bm' = insertBinder b' bm
                               in ForAllTy b' (reconType bm' x)
-reconType _  LitTy = LitTy
+reconType _  (LitTy litty) = LitTy litty
 reconType _  CoercionTy = CoercionTy

--- a/ghc-dump-util/src/GhcDump/ToHtml.hs
+++ b/ghc-dump-util/src/GhcDump/ToHtml.hs
@@ -136,7 +136,7 @@ typeToHtml t@(ForAllTy _ _)
     bndrsToHtml bndrs
     ". "
     typeToHtml t
-typeToHtml (LitTy) = "LIT"
+typeToHtml (LitTy litty) = "LIT"
 typeToHtml (CoercionTy) = "COERCION"
 
 tyConToHtml :: TyCon -> Html ()


### PR DESCRIPTION
- Spans can now also be `NoSpan`
- The source span location (being NoSpan or an actual span) is now saved in the Binder record.